### PR TITLE
Update Nav to match Ant Design site

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -46,6 +46,7 @@
     "prettier-plugin-svelte": "^0.7.0",
     "rollup": "^1.20.0",
     "rollup-plugin-babel": "^4.0.2",
+    "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-string": "^3.0.0",
     "rollup-plugin-svelte": "^5.0.1",
     "rollup-plugin-terser": "^4.0.4",

--- a/docs/rollup.config.js
+++ b/docs/rollup.config.js
@@ -8,6 +8,7 @@ import config from "sapper/config/rollup.js";
 import pkg from "./package.json";
 import { markdown } from "svelte-preprocess-markdown";
 import { string } from "rollup-plugin-string";
+import json from 'rollup-plugin-json';
 import alias from "@rollup/plugin-alias";
 import path from "path";
 import sveltePreprocess from 'svelte-preprocess';
@@ -67,6 +68,7 @@ export default {
         },
       }),
       commonjs(),
+      json(),
 
       legacy &&
         babel({
@@ -128,6 +130,7 @@ export default {
         },
       }),
       commonjs(),
+      json(),
 
       string({
         include: "**/*.txt",

--- a/docs/src/components/Nav.svelte
+++ b/docs/src/components/Nav.svelte
@@ -1,25 +1,93 @@
-<ul>
-  <li>
-    <a aria-current="{segment === undefined ? 'page' : undefined}" href=".">
-      Home
-    </a>
-  </li>
-  <li>
-    <a
-      aria-current="{segment === 'button' ? 'page' : undefined}"
-      href="button">
-      Button
-    </a>
-  </li>
-</ul>
+<div class="navigation">
+  <ul>
+    {#each navSections as section (section.name)}
+      <li>
+        <div class="group-title">
+          {section.name}
+        </div>
+        <ul>
+          {#each section.children as link (`${section.name}-${link}`)}
+            <li>
+              <a
+                class:current-link="{segment === link}"
+                class="nav-link"
+                href="{link}">
+                {startCase(link)}
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </li>
+    {/each}
+  </ul>
+</div>
+
 <script>
+  import navSections from '../nav.config.json';
+  import startCase from 'lodash/startCase';
+
   export let segment;
 
   const setAreaCurrent = link => (segment === link ? "page" : undefined);
 </script>
+
 <style>
-li{
-  padding-left: 2rem;
-  padding-bottom: 1rem;
+.navigation {
+  font-family: Avenir,-apple-system,BlinkMacSystemFont,segoe ui,Roboto,helvetica neue,Arial,noto sans,sans-serif,apple color emoji,segoe ui emoji,segoe ui symbol,noto color emoji,sans-serif;
+  width: 20%; /* TODO: Change when column component is available */
+  position: fixed;
+  top: 104px; /* top nav + 40px padding */
+  bottom: 0;
+  overflow-y: scroll;
+  border-right: 1px solid #f0f0f0;
+}
+
+.group-title {
+  height: 1.5715;
+  padding: 8px 16px 8px 40px;
+  color: rgba(0,0,0,.45);
+  font-size: 14px;
+  line-height: 1.5715;
+  margin-bottom: 16px;
+  font-size: 13px;
+}
+
+.group-title::after {
+  position: relative;
+  top: 12px;
+  display: block;
+  width: calc(100% - 20px);
+  height: 1px;
+  background: #f0f0f0;
+  content: '';
+}
+
+.nav-link {
+  display: block;
+  padding: 0 16px 0 40px;
+  height: 40px;
+  margin-top: 4px;
+  margin-bottom: 8px;
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 40px;
+  text-overflow: ellipsis;
+  color: rgba(0,0,0,.85);
+  text-decoration: none;
+}
+
+.current-link {
+  color: #1890ff;
+  background-color: #e6f7ff;
+  position: relative;
+}
+
+.current-link::after {
+  content: "";
+  height: 100%;
+  border-right: 3px solid #1890ff;
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 </style>

--- a/docs/src/nav.config.json
+++ b/docs/src/nav.config.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "General",
+    "children": [
+      "button",
+      "icon"
+    ]
+  },
+  {
+    "name": "Layout",
+    "children": [
+      "layout"
+    ]
+  },
+  {
+    "name": "Navigation",
+    "children": []
+  },
+  {
+    "name": "Data Entry",
+    "children": []
+  },
+  {
+    "name": "Data Display",
+    "children": []
+  },
+  {
+    "name": "Feedback",
+    "children": []
+  },
+  {
+    "name": "Other",
+    "children": []
+  }
+]

--- a/docs/src/routes/_layout.svelte
+++ b/docs/src/routes/_layout.svelte
@@ -1,25 +1,17 @@
-<Layout style="min-height: 100vh;">
-  <Header theme="light">
-    Awesome Svant
-  </Header>
-  <Layout>
-    <Sider theme="light" collapsible>
-      <Nav {segment} />
-    </Sider>
-    <Content>
-      <slot />
-    </Content>
-  </Layout>
-  <Footer />
-</Layout>
+<div class="header">
+  <div class="logo">Awesome Svant</div>
+</div>
+
+<div class="main-wrapper">
+  <Nav {segment} />
+  <div class="body">
+    <slot />
+  </div>
+</div>
+
 
 <script>
   import Nav from "../components/Nav.svelte";
-  import Layout from "@/components/layout/Layout.svelte";
-  import Header from "@/components/layout/Header.svelte";
-  import Sider from "@/components/layout/Sider.svelte";
-  import Content from "@/components/layout/Content.svelte";
-  import Footer from "@/components/layout/Footer.svelte";
 
   export let segment;
 </script>
@@ -28,11 +20,33 @@
   @import "../theme/index.less";
   @import "../../src/style/index.less";
 
-  main {
+  .header {
+    height: 64px;
+    background-color: #fff;
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+    box-shadow: 0 2px 8px #f0f1f2;
+    display: flex;
+    align-items: center;
+    z-index: 10;;
+  }
+
+  .logo {
+    padding-left: 40px;
+  }
+
+  .main-wrapper {
+    margin-top: 64px;
     position: relative;
-    background-color: white;
-    padding: 2em;
-    margin: 0 auto;
-    box-sizing: border-box;
+    padding: 40px 0 0;
+    background: #fff;
+  }
+
+  .body {
+    width: 80%;
+    margin-left: 20%;
+    padding: 0 64px;
   }
 </style>

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -5,14 +5,12 @@
 "@ant-design/colors@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@ant-design/colors/-/colors-4.0.0.tgz#bcc1183b1fdfd1587d4e655035b3fc47bf3a4ab6"
-  integrity sha512-XDb3Yc70UylZiSIGhQ+y05BJk2XXCCtxLY1UHESZ/5tGT5hlYfJBJik7CSZOyg+sbs5UHdVZpywk+LJDEXyqew==
   dependencies:
     tinycolor2 "^1.4.1"
 
 "@ant-design/icons-svg@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.0.0.tgz#6683db0df97c0c6900bb28a280faf391522ec734"
-  integrity sha512-Nai+cd3XUrv/z50gSk1FI08j6rENZ1e93rhKeLTBGwa5WrmHvhn2vowa5+voZW2qkXJn1btS6tdvTEDB90M0Pw==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
@@ -834,7 +832,6 @@ babel-plugin-dynamic-import-node@^2.3.0:
 babel-runtime@6.x:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
@@ -919,7 +916,6 @@ chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
 classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 clean-css@^4.2.1:
   version "4.2.3"
@@ -962,14 +958,12 @@ commander@^2.19.0, commander@~2.20.3:
 component-classes@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/component-classes/-/component-classes-1.2.6.tgz#c642394c3618a4d8b0b8919efccbbd930e5cd691"
-  integrity sha1-xkI5TDYYpNiwuJGe/Mu9kw5c1pE=
   dependencies:
     component-indexof "0.0.3"
 
 component-indexof@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/component-indexof/-/component-indexof-0.0.3.tgz#11d091312239eb8f32c8f25ae9cb002ffe8d3c24"
-  integrity sha1-EdCRMSI5648yyPJa6csAL/6NPCQ=
 
 compressible@~2.0.16:
   version "2.0.18"
@@ -1009,7 +1003,6 @@ core-js-compat@^3.6.2:
 core-js@^2.4.0:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
-  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -1037,7 +1030,6 @@ cross-spawn@^6.0.5:
 css-animation@^1.5.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/css-animation/-/css-animation-1.6.1.tgz#162064a3b0d51f958b7ff37b3d6d4de18e17039e"
-  integrity sha512-/48+/BaEaHRY6kNQ2OIPzKf9A6g8WjZYjhiNDNuIVbsm5tXCGIAsHDjB4Xu1C4vXJtUWZo26O68OQkDpNBaPog==
   dependencies:
     babel-runtime "6.x"
     component-classes "^1.2.5"
@@ -1313,7 +1305,6 @@ import-from@^2.1.0:
 inline-style-parser@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
-  integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
 
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
@@ -1477,7 +1468,6 @@ locate-path@^2.0.0:
 lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -1725,14 +1715,12 @@ postcss@^7.0.27:
 prettier-plugin-svelte@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-0.7.0.tgz#5ac0b9f194e0450c88ff1e167cbf3b32d2642df2"
-  integrity sha512-SuZSeMh48rx42kCFEpI/xE1XgjxQcS3r22Yo7jIhBYRhwbAa8laNxiIHsfeWWkX8BdyELkEayaTQp4ricckwTQ==
   dependencies:
     tslib "^1.9.3"
 
 prettier@^1.16.4:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 prism-svelte@^0.4.6:
   version "0.4.6"
@@ -1773,7 +1761,6 @@ qs@~6.5.2:
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
-  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
   dependencies:
     performance-now "^2.1.0"
 
@@ -1798,7 +1785,6 @@ regenerate@^1.4.0:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.4:
   version "0.13.5"
@@ -1886,6 +1872,12 @@ rollup-plugin-babel@^4.0.2:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.8.1"
 
+rollup-plugin-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-4.0.0.tgz#a18da0a4b30bf5ca1ee76ddb1422afbb84ae2b9e"
+  dependencies:
+    rollup-pluginutils "^2.5.0"
+
 rollup-plugin-string@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-string/-/rollup-plugin-string-3.0.0.tgz#fed2d6301fae1e59eb610957df757ef13fada3f0"
@@ -1909,7 +1901,7 @@ rollup-plugin-terser@^4.0.4:
     serialize-javascript "^1.6.1"
     terser "^3.14.1"
 
-rollup-pluginutils@^2.4.1, rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
+rollup-pluginutils@^2.4.1, rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   dependencies:
@@ -2103,7 +2095,6 @@ strip-indent@^3.0.0:
 style-to-object@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
-  integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
   dependencies:
     inline-style-parser "0.1.1"
 
@@ -2154,7 +2145,6 @@ tiny-emitter@^2.0.0:
 tinycolor2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
-  integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -2163,7 +2153,6 @@ to-fast-properties@^2.0.0:
 to-style@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/to-style/-/to-style-1.3.3.tgz#63a2b70a6f4a7d4fdc2ed57a0be4e7235cb6699c"
-  integrity sha1-Y6K3Cm9KfU/cLtV6C+TnI1y2aZw=
 
 tough-cookie@~2.5.0:
   version "2.5.0"
@@ -2181,7 +2170,6 @@ trouter@^3.1.0:
 tslib@^1.10.0, tslib@^1.9.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
-  integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Since we want a scrollable side nav, using the Layout components were not working so well. I refactored the nav so that I could customize it. I also added a nav config file that we can update instead of adding links to the nav svelte file. When I create the `createNewComponent` script, it will modify this config as well.

![Screen Shot 2020-04-16 at 1 17 08 AM](https://user-images.githubusercontent.com/10605146/79417661-aa6c7f00-7f80-11ea-8089-819b9073103b.jpg)
