### PR TITLE
Fix reactivity of the separator

### DIFF
--- a/src/components/breadcrumb/Breadcrumb.svelte
+++ b/src/components/breadcrumb/Breadcrumb.svelte
@@ -4,13 +4,19 @@
 
 <script>
   import { setContext } from "svelte";
+  import { writable } from "svelte/store";
 
   // ********************** Props **********************
 
   // Sets the separator for all the BreadcrumbItem children. They can override this individually.
   export let separator = "/";
 
-  setContext("uniformedSeparator", separator);
+  // ********************** /Props **********************
+
+  let uniformedSeparator = writable(separator);
+  $: uniformedSeparator.set(separator);
+
+  setContext("uniformedSeparator", uniformedSeparator);
 </script>
 
 <style lang="less" global>

--- a/src/components/breadcrumb/BreadcrumbItem.svelte
+++ b/src/components/breadcrumb/BreadcrumbItem.svelte
@@ -17,6 +17,7 @@
 
 <script>
   import { onMount, getContext } from "svelte";
+  import { writable } from "svelte/store";
 
   // ********************** Props **********************
 
@@ -27,8 +28,11 @@
 
   // ********************** /Props **********************
 
+  let uniformedSeparator = getContext("uniformedSeparator");
+  let separatorToUse;
+  let separatorIsComponent;
   // either uses the separator passed directly as a prop or using the prop passed in from the parent Breadcrumb component
-  let separatorToUse = separator || getContext("uniformedSeparator");
+  $: separatorToUse = separator || $uniformedSeparator;
   // boolean to tell us if a Svelte component is passed as the separator
-  let separatorIsComponent = typeof separatorToUse === "function";
+  $: separatorIsComponent = typeof separatorToUse === "function";
 </script>


### PR DESCRIPTION
This small change fixes the reactivity of the separator, if we don't do it like this if the separator is changed that will not be reflected in the component

## Before
![](http://g.recordit.co/QN5eMdxq5E.gif)


## After
![](http://g.recordit.co/XROo6I4MZK.gif)

